### PR TITLE
Add sticky table of contents sidebar to posts

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -590,6 +590,106 @@
     }
 }
 
+// Table of Contents sidebar
+.toc {
+    position: fixed;
+    top: 5rem;
+    right: 2rem;
+    width: 210px;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+    font-size: 13px;
+    z-index: 500;
+
+    // Only show when there's room beside the content column
+    @media screen and (max-width: 1200px) {
+        display: none;
+    }
+
+    .toc-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.6rem;
+    }
+
+    .toc-title {
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        color: $text-color;
+    }
+
+    .toc-toggle {
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-size: 12px;
+        color: $grey-color;
+        padding: 0;
+        transition: color 0.15s ease;
+
+        &:hover { color: $brand-color; }
+    }
+
+    .toc-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+
+        &.toc-list--hidden { display: none; }
+    }
+
+    .toc-item {
+        border-left: 2px solid $grey-color-light;
+        transition: border-left-color 0.2s ease;
+
+        a {
+            display: block;
+            padding: 0.28rem 0 0.28rem 0.65rem;
+            color: $grey-color;
+            line-height: 1.4;
+            transition: color 0.15s ease;
+
+            &:hover {
+                color: $text-color;
+                text-decoration: none;
+            }
+        }
+
+        &.toc-item--active {
+            border-left-color: $brand-color;
+
+            > a { color: $text-color; font-weight: 500; }
+        }
+
+        &.toc-h3 { padding-left: 0.75rem; }
+    }
+
+    [data-theme="dark"] & {
+        .toc-title { color: $text-color-dark; }
+
+        .toc-toggle {
+            color: $grey-color-dark-theme;
+            &:hover { color: $brand-color-dark; }
+        }
+
+        .toc-item {
+            border-left-color: $border-color-dark;
+
+            a {
+                color: $grey-color-dark-theme;
+                &:hover { color: $text-color-dark; }
+            }
+
+            &.toc-item--active {
+                border-left-color: $brand-color-dark;
+                > a { color: $text-color-dark; }
+            }
+        }
+    }
+}
+
 // Footnotes section at bottom of post
 .footnotes {
     margin-top: 2.5rem;

--- a/js/post-enhancements.js
+++ b/js/post-enhancements.js
@@ -94,4 +94,97 @@
     document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') closePopup();
     });
+
+    // ── Table of Contents ─────────────────────────────────────────────────────
+    var postContent = document.querySelector('.post-content');
+    if (postContent) {
+        var headings = Array.prototype.slice.call(
+            postContent.querySelectorAll('h2[id], h3[id]')
+        );
+        if (headings.length >= 3) {
+            buildTOC(headings);
+        }
+    }
+
+    function headingText(el) {
+        var clone = el.cloneNode(true);
+        clone.querySelectorAll('.heading-anchor').forEach(function (a) { a.remove(); });
+        return clone.textContent.trim();
+    }
+
+    function buildTOC(headings) {
+        var toc = document.createElement('nav');
+        toc.className = 'toc';
+        toc.setAttribute('aria-label', 'Table of contents');
+
+        var header = document.createElement('div');
+        header.className = 'toc-header';
+
+        var title = document.createElement('strong');
+        title.className = 'toc-title';
+        title.textContent = 'CONTENTS';
+
+        var toggleBtn = document.createElement('button');
+        toggleBtn.className = 'toc-toggle';
+        toggleBtn.textContent = 'hide';
+
+        header.appendChild(title);
+        header.appendChild(toggleBtn);
+        toc.appendChild(header);
+
+        var list = document.createElement('ul');
+        list.className = 'toc-list';
+
+        var items = [];
+        headings.forEach(function (h) {
+            var li = document.createElement('li');
+            li.className = 'toc-item toc-' + h.tagName.toLowerCase();
+            li.dataset.target = h.id;
+
+            var a = document.createElement('a');
+            a.href = '#' + h.id;
+            a.textContent = headingText(h);
+
+            li.appendChild(a);
+            list.appendChild(li);
+            items.push(li);
+        });
+
+        toc.appendChild(list);
+        document.body.appendChild(toc);
+
+        // Restore collapsed state from localStorage
+        if (localStorage.getItem('toc-hidden') === 'true') {
+            list.classList.add('toc-list--hidden');
+            toggleBtn.textContent = 'show';
+            toggleBtn.setAttribute('aria-label', 'Show table of contents');
+        } else {
+            toggleBtn.setAttribute('aria-label', 'Hide table of contents');
+        }
+
+        toggleBtn.addEventListener('click', function () {
+            var nowHidden = list.classList.toggle('toc-list--hidden');
+            toggleBtn.textContent = nowHidden ? 'show' : 'hide';
+            toggleBtn.setAttribute('aria-label', (nowHidden ? 'Show' : 'Hide') + ' table of contents');
+            localStorage.setItem('toc-hidden', nowHidden);
+        });
+
+        // Scroll-spy: highlight the heading currently in view
+        if ('IntersectionObserver' in window) {
+            var activeId = headings[0] ? headings[0].id : null;
+
+            var observer = new IntersectionObserver(function (entries) {
+                entries.forEach(function (entry) {
+                    if (entry.isIntersecting) {
+                        activeId = entry.target.id;
+                    }
+                });
+                items.forEach(function (li) {
+                    li.classList.toggle('toc-item--active', li.dataset.target === activeId);
+                });
+            }, { rootMargin: '-68px 0px -60% 0px', threshold: 0 });
+
+            headings.forEach(function (h) { observer.observe(h); });
+        }
+    }
 })();


### PR DESCRIPTION
## Summary

- Auto-generates a sticky TOC sidebar for any post with 3+ headings (h2/h3)
- Fixed to the right of the content column; hidden below 1200px viewport width
- Scroll-spy via `IntersectionObserver` highlights the active section with a blue left border
- Hide/show toggle button that persists state in `localStorage` across page loads
- Full dark-mode support matching the site's existing theme

## Test plan

- [ ] Open a post with multiple headings (e.g. `/en/great-commit-messages-ai-era`) on a wide viewport (≥1200px) and confirm the CONTENTS sidebar appears
- [ ] Click "hide" — list collapses; reload the page — it stays collapsed
- [ ] Click "show" — list re-appears
- [ ] Scroll through the post and confirm the active heading is highlighted
- [ ] Resize to <1200px and confirm the TOC is hidden
- [ ] Toggle dark mode and confirm colors match the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)